### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         }
     ],
     "require": {
+        "symfony/filesystem": "dev-master",
         "symfony/dependency-injection": "dev-master",
         "symfony/yaml": "dev-master",
         "symfony/config": "dev-master"


### PR DESCRIPTION
Without it you'd get:

Loading composer repositories with package information
Installing dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfony/config dev-master -> satisfiable by symfony/config[dev-master].
    - symfony/config dev-master requires symfony/filesystem ~2.8|~3.0 -> no matching package found.

Potential causes:
- A typo in the package name
- The package is not available in a stable-enough version according to your minimum-stability setting
  see https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion for more details.

Read http://getcomposer.org/doc/articles/troubleshooting.md for further common problems.
